### PR TITLE
Prevent default action on click handler

### DIFF
--- a/app/components/spin-button.js
+++ b/app/components/spin-button.js
@@ -64,7 +64,8 @@ export default Ember.Component.extend({
 
   _timer: null,
 
-  click: function() {
+  click: function(event) {
+    event.preventDefault();
     this.set('inFlight', true);
 
     if (this.attrs && 'function' === typeof this.attrs.action) {


### PR DESCRIPTION
Spin buttons currently don't prevent the default browser action in their `click` handler, resulting in unintended side effects – for example, spin buttons within forms causing the page to reload as the browser "submits" the form. This change makes `{{#spin-button action=(action 'save')}}` behave the same as `<button {{action 'save'}}>`.