### PR TITLE
Allowing to use defaultTimeout property name

### DIFF
--- a/app/components/spin-button.js
+++ b/app/components/spin-button.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import createSpinner from 'ember-spin-button/utils/spinner';
 
-const { observer } = Ember;
+const { observer, computed: { alias } } = Ember;
 
 export default Ember.Component.extend({
   tagName: 'button',
@@ -22,6 +22,8 @@ export default Ember.Component.extend({
   classNameBindings: ['inFlight:in-flight:ready', ':spin-button'],
 
   _timer: null,
+
+  defaultTimeout: alias('defaultTimout'),
 
   click: function (event) {
     event.preventDefault();


### PR DESCRIPTION
There is a property named ``defaultTimout`` - I cannot find "timout" word in English (not a native speaker :) ), so I think it's a typo. I think it may lead to mistakes in code, because it should be ``defaultTimeout``. For backward-compatibility it adds just an alias.